### PR TITLE
Update step_1_upgrade_framework.json for v1.5.1 framework

### DIFF
--- a/metadata/v1.5.1/step_1_upgrade_framework.json
+++ b/metadata/v1.5.1/step_1_upgrade_framework.json
@@ -1,6 +1,6 @@
 {
   "title": "Proposal to upgrade mainnet framework to v1.5.1",
   "description": "This includes changes outlined in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-framework-v1.5.1. New public functions in aptos_token to make creating tokens and collections easier.",
-  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/tree/main/sources/v1.5.1",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/tree/main/sources/v1.5.1/step_1_upgrade_framework",
   "discussion_url": "https://github.com/aptos-labs/aptos-core/issues/9557"
 }


### PR DESCRIPTION
The URL in the metadata should say /v1.5.1/step_1_upgrade_framework instead of just v1.5.1/