### PR TITLE
Enable order votes (AIP 89)

### DIFF
--- a/metadata/2024-07-16-enable-order-votes/enable_order_votes.json
+++ b/metadata/2024-07-16-enable-order-votes/enable_order_votes.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable the order votes feature in the on chain consensus config",
+  "description": "Enables the changes in AIP-89 https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-89.md",
+  "source_code_url": "https://github.com/aptos-labs/aptos-core",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/451"
+}

--- a/metadata/2024-07-16-enable-order-votes/enable_order_votes.json
+++ b/metadata/2024-07-16-enable-order-votes/enable_order_votes.json
@@ -1,6 +1,6 @@
 {
   "title": "Enable the order votes feature in the on chain consensus config",
   "description": "Enables the changes in AIP-89 https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-89.md",
-  "source_code_url": "https://github.com/aptos-labs/aptos-core",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-07-16-enable-order-votes",
   "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/451"
 }

--- a/sources/2024-07-16-enable-order-votes/0-consensus-config.move
+++ b/sources/2024-07-16-enable-order-votes/0-consensus-config.move
@@ -1,0 +1,48 @@
+// Script hash: 4e2c77d8 
+// Consensus config upgrade proposal
+
+// config: V3 {
+//     alg: JolteonV2 {
+//         main: ConsensusConfigV1 {
+//             decoupled_execution: true,
+//             back_pressure_limit: 10,
+//             exclude_round: 40,
+//             proposer_election_type: LeaderReputation(
+//                 ProposerAndVoterV2(
+//                     ProposerAndVoterConfig {
+//                         active_weight: 1000,
+//                         inactive_weight: 10,
+//                         failed_weight: 1,
+//                         failure_threshold_percent: 10,
+//                         proposer_window_num_validators_multiplier: 10,
+//                         voter_window_num_validators_multiplier: 1,
+//                         weight_by_voting_power: true,
+//                         use_history_from_previous_epoch_max_count: 5,
+//                     },
+//                 ),
+//             ),
+//             max_failed_authors_to_store: 10,
+//         },
+//         quorum_store_enabled: true,
+//         order_vote_enabled: true,
+//     },
+//     vtxn: V1 {
+//         per_block_limit_txn_count: 3,
+//         per_block_limit_total_bytes: 2097152,
+//     },
+// }
+
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::consensus_config;
+    use std::vector;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, vector::empty<u8>());
+
+        let consensus_blob: vector<u8> = x"0202010a0000000000000028000000000000000201e8030000000000000a0000000000000001000000000000000a0000000a00000000000000010000000000000001050000000a0000000000000001010103000000000000000000200000000000";
+
+        consensus_config::set_for_next_epoch(&framework_signer, consensus_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
We define the consensus latency to be the time taken for validators to order a block proposal under the common case. This AIP proposes a solution to reduce the consensus latency from 4 hops to 3 hops by introducing a novel protocol change that involves a new type of votes called “order votes”. Check https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-89.md for more details.