### PR TITLE
governance proposals for concurrent fa balance

### DIFF
--- a/metadata/2024-08-30-enable-concurrent-fungible-balance/enable_concurrent_fungible_balance.json
+++ b/metadata/2024-08-30-enable-concurrent-fungible-balance/enable_concurrent_fungible_balance.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable for accounts to opt-in into concurrent fungible balance",
+  "description": "Enables the changes in AIP-70 https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-70.md",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-08-30-enable-concurrent-fungible-balance/0-features.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/359"
+}

--- a/sources/2024-08-30-enable-concurrent-fungible-balance/0-features.move
+++ b/sources/2024-08-30-enable-concurrent-fungible-balance/0-features.move
@@ -1,0 +1,25 @@
+// Script hash: 82bcf277 
+// Modifying on-chain feature flags:
+// Enabled Features: [ConcurrentFungibleBalance]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+    use std::vector;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, vector::empty<u8>());
+
+        let enabled_blob: vector<u64> = vector[
+            67,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a short summary about this new proposal, add AIP link here if it's corresponding to an AIP. If it does not associated with any AIP, explain why this is required-->
AIP: [AIP-70](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-70.md)
Release: supported by [v1.14](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.14.0)

## Security Consideration
Main capability powering this feature is AggregatorsV2. They have been extensively tested (including replay is the same when they are using simple sequential fallback), and audited by OtterSec, and have been in production for months. 

Code for concurrent FA balance itself is short, and has been audited by Aptos Labs. For the past 3 weeks, we have run devnet with defaulting all new accounts to concurrent FA balance.

## Test Result
state-sync via execution mode on devnet, with aggregators disabled, succeeds. 
This feature has been enabled in devnet and testnet since end of June.

for aggregators themselves, passing replay-verify of mainnet and testnet, with simple sequential fallback.

## Ecosystem Impact
In [v1.14](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.14.0), we have the callout:

### Breaking Changes

- [**[AIP-70]** Parallelize Fungible Assets](https://github.com/aptos-foundation/AIPs/issues/359) - opt-in parallel fungible balance
    - **Ecosystem Impact:** In order to track fungible asset balances correctly (for the accounts that opt-in to the new feature), now both old and new field needs to be summed up: `FungibleStore.balance` + `ConcurrentFungibleBalance.balance`. If using indexer, [this change](https://github.com/aptos-labs/aptos-indexer-processors/pull/338) will make it transparently handled by provided processors. `fungible_asset::balance` view function will continue providing correct balance.
    - **Dependencies:** None
    - **Feature Flag:** `CONCURRENT_FUNGIBLE_BALANCE`


<!-- Thank you for your contribution! -->
