### PR TITLE
adding proposal to enable federated keyless accounts

### DIFF
--- a/metadata/2024-09-19-enable-federated-keyless/enable_federated_keyless.json
+++ b/metadata/2024-09-19-enable-federated-keyless/enable_federated_keyless.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable the federated Keyless account feature",
+  "description": "Enables the federated Keyless feature in AIP-96 (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-96.md)",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-09-10-enable-federated-keyless/0-features.move", 
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/490"
+}

--- a/sources/2024-09-19-enable-federated-keyless/0-features.move
+++ b/sources/2024-09-19-enable-federated-keyless/0-features.move
@@ -1,0 +1,25 @@
+// Script hash: aca302f4 
+// Modifying on-chain feature flags:
+// Enabled Features: [FederatedKeyless]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+    use std::vector;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, vector::empty<u8>());
+
+        let enabled_blob: vector<u64> = vector[
+            77,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description


This AIP seeks to extend the [**keyless account** architecture](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md) to support more **OpenID Connect (OIDC) providers**, beyond the ones that are allow-listed in `0x1::jwks` via [JWK consensus](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-67.md), while maintaining its *decentralization*.

The high-level approach is to introduce a new **federated keyless account** type whose [public key](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md#public-keys) additionally contains an Aptos account address where the OIDC provider’s JWKs are to be found. In other words, a federated keyless account address contains a pointer to the JWKs that are to be used to validate its [keyless signatures](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md#zero-knowledge-signatures).

AIP: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-96.md
AIP discussion: https://github.com/aptos-foundation/AIPs/issues/490
Release: v1.19

## Security Consideration
<!-- Please include a short summary about the security auditing result. e.g. Audited by OtterSec / audited by Aptos Labs team, all security concerns addressed. -->

TBD.

## Test Result

TBD.

For now, we have end-to-end tests in the Aptos VM, smoke tests and [SDK tests](https://github.com/aptos-labs/aptos-ts-sdk/blob/41fbf270e01cd37298ed3d828309bda6151d9a02/tests/e2e/api/keyless.test.ts#L4).

## Ecosystem Impact

<!-- Please include a short summary on the ecosystem impact you want to highlight here. e.g. All fullnode operator need to upgrade their node to 1.20 -->

All full node operators need to upgrade their node to 1.19.

<!-- Thank you for your contribution! -->
