### PR TITLE
Enable the multisig prologue check to abort if the multisig payload does not match

### DIFF
--- a/metadata/2024-09-19-enable-multisig-prologue-check/enable_abort_if_multisig_payload_mismatch.json
+++ b/metadata/2024-09-19-enable-multisig-prologue-check/enable_abort_if_multisig_payload_mismatch.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable the multisig prologue check to abort if the multisig payload does not match",
+  "description": "Aborts the multisig transaction if the provided payload does not match the payload stored onchain",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/tree/main/sources/2024-09-19-enable-multisig-prologue-check",
+  "discussion_url": "https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.15.0"
+}

--- a/sources/2024-09-19-enable-multisig-prologue-check/0-features.move
+++ b/sources/2024-09-19-enable-multisig-prologue-check/0-features.move
@@ -1,0 +1,25 @@
+// Script hash: 19e37a58 
+// Modifying on-chain feature flags:
+// Enabled Features: [AbortIfMultisigPayloadMismatch]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+    use std::vector;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, vector::empty<u8>());
+
+        let enabled_blob: vector<u64> = vector[
+            70,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
This update enables the multisig prologue check to abort a multisig transaction if the provided payload does not match the payload stored on-chain. It resolves the issue where mismatched payloads were silently ignored: https://github.com/aptos-labs/aptos-core/issues/12929.

Release: This fix has been included in the v1.15 release, behind the feature flag `abort_if_multisig_payload_mismatch `.

## Security Consideration
This update addresses the issue outlined above without introducing any new security concerns.

## Test Result
Testing on the testnet confirmed that the fix works as expected, explicitly aborting transactions when the provided payload does not match the one that has been stored on-chain, rather than implicitly ignoring the mismatch. We observed the expected error message during payload mismatch testing on the testnet:
```
{
  "Error": "API error: API error Error(VmError): Invalid transaction: Type: Validation Code: MULTISIG_TRANSACTION_PAYLOAD_DOES_NOT_MATCH"
}
```

## Ecosystem Impact
No further action is required from the ecosystem side.


