### PR TITLE
[AIP-85] Enable native derived address

### DIFF
--- a/metadata/2024-08-30-enable-native-object-derived-address/enable_object_native_derived_address.json
+++ b/metadata/2024-08-30-enable-native-object-derived-address/enable_object_native_derived_address.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable the native call to compute object derived address",
+  "description": "Enables the changes in AIP-85 https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-85.md",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-08-30-enable-native-object-derived-address/0-features.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/458"
+}

--- a/sources/2024-08-30-enable-native-object-derived-address/0-features.move
+++ b/sources/2024-08-30-enable-native-object-derived-address/0-features.move
@@ -1,0 +1,25 @@
+// Script hash: 6f5935ab 
+// Modifying on-chain feature flags:
+// Enabled Features: [ObjectNativeDerivedAddress]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+    use std::vector;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, vector::empty<u8>());
+
+        let enabled_blob: vector<u64> = vector[
+            62,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
AIP: [AIP-85](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-85.md)
Release: supported by [v1.14](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.14.0)

## Security Consideration
Moving execution of hot function from move to native code (rust) for efficiency improvement. 

Provided unit tests confirm that behavior doesn't change. 

## Test Result
This feature has been enabled in devnet and testnet since end of June, without issues.

## Ecosystem Impact
no ecosystem impact