### PR TITLE
Enable AIP-68 UseCaseAwareShuffler

### DIFF
--- a/metadata/2024-09-27-use-case-aware-shuffler/enable-use-case-aware-shuffler.json
+++ b/metadata/2024-09-27-use-case-aware-shuffler/enable-use-case-aware-shuffler.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable the Use Case Aware Shuffler",
+  "description": "Enables the changes in AIP-86",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-09-27-enable-use-case-aware-shuffler/enable-use-case-aware-shuffler.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/333"
+}

--- a/sources/2024-09-27-use-case-aware-shuffler/enable-use-case-aware-shuffler.move
+++ b/sources/2024-09-27-use-case-aware-shuffler/enable-use-case-aware-shuffler.move
@@ -1,0 +1,40 @@
+// Script hash: d62195fc 
+// Execution config upgrade proposal
+
+// config: V4(
+//     ExecutionConfigV4 {
+//         transaction_shuffler_type: UseCaseAware {
+//             sender_spread_factor: 32,
+//             platform_use_case_spread_factor: 0,
+//             user_use_case_spread_factor: 4,
+//         },
+//         block_gas_limit_type: ComplexLimitV1 {
+//             effective_block_gas_limit: 30000,
+//             execution_gas_effective_multiplier: 1,
+//             io_gas_effective_multiplier: 1,
+//             conflict_penalty_window: 9,
+//             use_granular_resource_group_conflicts: false,
+//             use_module_publishing_block_conflict: true,
+//             block_output_limit: Some(
+//                 5242880,
+//             ),
+//             include_user_txn_size_in_block_output: true,
+//             add_block_limit_outcome_onchain: false,
+//         },
+//         transaction_deduper_type: TxnHashAndAuthenticatorV1,
+//     },
+// )
+
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::execution_config;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let execution_blob: vector<u8> = x"040420000000000000000000000000000000040000000000000002307500000000000001000000000000000100000000000000090000000001010000500000000000010001";
+
+        execution_config::set_for_next_epoch(&framework_signer, execution_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a short summary about this new proposal, add AIP link here if it's corresponding to an AIP. If it does not associated with any AIP, explain why this is required-->

This AIP proposes to update the Transaction Shuffler logic to add other reasons for conflicts to how transactions are ordered in the block. In addition to using senders to spread out transactions (from [AIP-27](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-27.md)), this AIP will extend that to spread out adjacent transactions (in the proposed order) that are relevant to the same "use case", as an approximation of having higher likelihood of conflicting. Defining a "use case" as the author of the contract being invoked by the transaction, for now, the new algorithm gives transactions from non-dominant contract a better chance of surviving a potential block cut resulting from the conflicting transactions hitting the effective block gas limit early, without meaningfully affecting conflicting workload, unless the system is heavily overloaded.

AIP: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-68.md
Release: v1.20

## Security Consideration
<!-- Please include a short summary about the security auditing result. e.g. Audited by OtterSec / audited by Aptos Labs team, all security concerns addressed. -->

N/A


## Test Result
<!-- Please include a short summary on the test result. e.g. Feature tested on testnet, verified the function is fully working and indexed corrected. -->

@igor-aptos  did extensive test on DevNet and seeing latency benefits as expected. Gas estimation API has also been recently updated so that when a dominating use case is present, gas estimation for others don't increase.

## Ecosystem Impact
<!-- Please include a short summary on the ecosystem impact you want to highlight here. e.g. All fullnode operator need to upgrade their node to 1.20 -->

Ecosystem will see new gas estimation after upgrading fullnodes but generally not much impact on the ecosystem.
(Validators needs to update binary before enabling)


<!-- Thank you for your contribution! -->
