### PR TITLE
Mainnt proposal for enabling the feature SignerNativeFormatFix

### DIFF
--- a/metadata/2024-10-25-signer-native-format-fix/enable_signer_native_format_fix.json
+++ b/metadata/2024-10-25-signer-native-format-fix/enable_signer_native_format_fix.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable the signer native format fix",
+  "description": "Fixes the issue of string_utils::native_format in formatting signer values",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-10-25-signer-native-format-fix/0-features.move",
+  "discussion_url": "https://github.com/aptos-labs/aptos-core/issues/8865"
+}

--- a/sources/2024-10-25-signer-native-format-fix/0-features.move
+++ b/sources/2024-10-25-signer-native-format-fix/0-features.move
@@ -1,0 +1,24 @@
+// Script hash: 0f6ab7df 
+// Modifying on-chain feature flags:
+// Enabled Features: [SignerNativeFormatFix]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+            25,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
This update fixes the issue (https://github.com/aptos-labs/aptos-core/issues/8865.) of string_utils::native_format in formatting signer values.

## Security Consideration
This update addresses the issue outlined above without introducing any new security concerns.

## Test Result
Tested on the devnet and the testnet, and confirmed that `native_format` works as expected for signers.
The following is the testnet transaction result:
```
Transaction submitted: https://explorer.aptoslabs.com/txn/0xa0afeb8ad6c19a8d393356673b15adaab797f0840e854fe750e46a7681cc56f8
{
  "Result": {
    "transaction_hash": "0xa0afeb8ad6c19a8d393356673b15adaab797f0840e854fe750e46a7681cc56f8",
    "gas_used": 847,
    "gas_unit_price": 100,
    "sender": "c3f4205e1f3d52fcd74385dfaabdd96edb6943a26db0ad8e6e7f7dd02b66ff85",
    "sequence_number": 12,
    "success": true,
    "timestamp_us": 1729907047562291,
    "version": 1842134318,
    "vm_status": "Executed successfully"
  }
}
```


## Ecosystem Impact
No further action is required from the ecosystem side.

<!-- Thank you for your contribution! -->
