### PR TITLE
enable collection owner

### DIFF
--- a/metadata/2024-12-09-enable-collection-owner/enable-collection-owner.json
+++ b/metadata/2024-12-09-enable-collection-owner/enable-collection-owner.json
@@ -1,4 +1,5 @@
-tle": "Enable AIP 95 Collection Owner",
+{
+  "title": "Enable AIP 95 Collection Owner",
   "description": "Enable creating collections with permissions as the owner of the collection",
   "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-12-09-enable-collection-owner/enable-collection-owner.move",
   "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/489"

--- a/metadata/2024-12-09-enable-collection-owner/enable-collection-owner.json
+++ b/metadata/2024-12-09-enable-collection-owner/enable-collection-owner.json
@@ -1,0 +1,5 @@
+tle": "Enable AIP 95 Collection Owner",
+  "description": "Enable creating collections with permissions as the owner of the collection",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2024-12-09-enable-collection-owner/enable-collection-owner.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/489"
+}

--- a/sources/2024-12-09-enable-collection-owner/enable-collection-owner.move
+++ b/sources/2024-12-09-enable-collection-owner/enable-collection-owner.move
@@ -1,0 +1,24 @@
+// Script hash: 4f87e5b4 
+// Modifying on-chain feature flags:
+// Enabled Features: [CollectionOwner]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+            79,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
This AIP allows collections to be created as the owner of the collection object. This means ownership of the collection can be transferred, allowing new owners to own full collection permissions such as creating new tokens.

AIP: AIP 95 - [Collections Permissions Update](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-95.md)
Release:
Type: Technical

## Security Consideration
[Security team verified looks good](https://aptos-org.slack.com/archives/C045G5Q0V8W/p1733340957916749?thread_ts=1733335858.269079&cid=C045G5Q0V8W)

## Test Result
Feature tested on testnet, verified the function is fully working with correct security permissions. 

**Testing**

Created 2 collections from "X" address.
1. fixed collection as owner
2. unlimited collection as owner

**Verifying**
1. Minted tokens from both collections as owner as "X" address.
2. Transferred collection ownership to "Y" address.
3. Logged in as "X" address, after transferring, not able to mint any new tokens.
4. Logged in as "Y" address, able to mint new tokens as "Y" is the new address.

## Ecosystem Impact
New functions added to framework, so not impact.