### PR TITLE
Disallow init module to publish modules

### DIFF
--- a/metadata/2025-10-02-disallow-init-module-to-publish-modules/disallow_init_module_to_publish_modules.json
+++ b/metadata/2025-10-02-disallow-init-module-to-publish-modules/disallow_init_module_to_publish_modules.json
@@ -1,0 +1,6 @@
+{
+  "title": "Disallow init module to attempt to publish modules",
+  "description": "This feature improves module publishing developer experience, amd is required for V2 loader",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-10-02-disallow-init-module-to-publish-modules/0-features.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/533"
+}

--- a/metadata/2025-10-02-disallow-init-module-to-publish-modules/disallow_init_module_to_publish_modules.json
+++ b/metadata/2025-10-02-disallow-init-module-to-publish-modules/disallow_init_module_to_publish_modules.json
@@ -1,6 +1,6 @@
 {
   "title": "Disallow init module to attempt to publish modules",
-  "description": "This feature improves module publishing developer experience, amd is required for V2 loader",
+  "description": "This feature improves module publishing developer experience, and is required for V2 loader",
   "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-10-02-disallow-init-module-to-publish-modules/0-features.move",
   "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/533"
 }

--- a/metadata/2025-10-02-disallow-init-module-to-publish-modules/disallow_init_module_to_publish_modules.json
+++ b/metadata/2025-10-02-disallow-init-module-to-publish-modules/disallow_init_module_to_publish_modules.json
@@ -1,6 +1,6 @@
 {
   "title": "Disallow init module to attempt to publish modules",
-  "description": "This feature improves module publishing developer experience, and is required for V2 loader",
+  "description": "This feature improves module publishing developer experience, and is part of the V2 loader improvements",
   "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-10-02-disallow-init-module-to-publish-modules/0-features.move",
   "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/533"
 }

--- a/sources/2025-10-02-disallow-init-module-to-publish-modules/0-features.move
+++ b/sources/2025-10-02-disallow-init-module-to-publish-modules/0-features.move
@@ -1,0 +1,24 @@
+// Script hash: 398e69c4 
+// Modifying on-chain feature flags:
+// Enabled Features: [DisallowInitModuleToPublishModules]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+            82,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a short summary about this new proposal, add AIP link here if it's corresponding to an AIP. If it does not associated with any AIP, explain why this is required-->
AIP: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-107.md
Release: 1.26
Type: Technical

## Security Consideration

Reviewed by Aptos Labs security team.

## Test Result

Tested on testnet.

## Ecosystem Impact

Improved user experience for `init_modules`.


<!-- Thank you for your contribution! -->
