### PR TITLE
Enable module event (AIP-71) on mainnet

### DIFF
--- a/metadata/2025-04-16-module-event-migration/module_event_migration.json
+++ b/metadata/2025-04-16-module-event-migration/module_event_migration.json
@@ -1,0 +1,6 @@
+{
+  "title": "AIP-71: Refactor Aptos Framework Events with Module Events",
+  "description": "This AIP refactor the aptos framework events to module events except for coin module",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-04-16-module-event-migration/0-features.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/367"
+}

--- a/sources/2025-04-16-module-event-migration/0-features.move
+++ b/sources/2025-04-16-module-event-migration/0-features.move
@@ -1,0 +1,24 @@
+// Script hash: 60ee085d 
+// Modifying on-chain feature flags:
+// Enabled Features: [ModuleEventMigration]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+            57,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
enable module events emitting in aptos-framework on mainnet except for coin module.
Coin module event will be deprecated after migrating to FA.

AIP: 71
Release: v1.28
Type: Technical

## Ecosystem Impact
Some downstream indexing service has to update their code.
