### PR TITLE
All new accounts will only create fa store by default

### DIFF
--- a/metadata/2025-06-11-new-accounts-default-to-fa-store/new_account_default_to_fa_store.json
+++ b/metadata/2025-06-11-new-accounts-default-to-fa-store/new_account_default_to_fa_store.json
@@ -1,0 +1,6 @@
+{
+  "title": "New Accounts Default to FA Store",
+  "description": "This is a preparation stemp for AIP-63 that all new accounts will create FA store instead of coin store",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-06-11-new-accounts-default-to-fa-store/0-features.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-85.md"
+}

--- a/metadata/2025-06-11-new-accounts-default-to-fa-store/new_account_default_to_fa_store.json
+++ b/metadata/2025-06-11-new-accounts-default-to-fa-store/new_account_default_to_fa_store.json
@@ -1,6 +1,0 @@
-{
-  "title": "New Accounts Default to FA Store",
-  "description": "This is a preparation stemp for AIP-63 that all new accounts will create FA store instead of coin store",
-  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-06-11-new-accounts-default-to-fa-store/0-features.move",
-  "discussion_url": "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-85.md"
-}

--- a/metadata/2025-06-11-new-accounts-default-to-fa-store/new_accounts_default_to_fa_store.json
+++ b/metadata/2025-06-11-new-accounts-default-to-fa-store/new_accounts_default_to_fa_store.json
@@ -1,0 +1,6 @@
+{
+  "title": "New Accounts Default to FA Store",
+  "description": "This is a preparation step for AIP-63 that all new accounts will create FA store instead of coin store",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-06-11-new-accounts-default-to-fa-store",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-85.md"
+}

--- a/sources/2025-06-11-new-accounts-default-to-fa-store/0-features.move
+++ b/sources/2025-06-11-new-accounts-default-to-fa-store/0-features.move
@@ -1,0 +1,24 @@
+// Script hash: 6e5dc4c2 
+// Modifying on-chain feature flags:
+// Enabled Features: [NewAccountsDefaultToFaAptStore, NewAccountsDefaultToFaStore]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+            64, 90,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
The first step of https://aptosfoundation.org/currents/migrating-to-fungible-asset-standard
enable two features at once:
NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE
NEW_ACCOUNTS_DEFAULT_TO_FA_STORE

It's related to two AIPs.
AIP 1: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-63.md
AIP 2: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-85.md
Release: v1.30
type: Technical

## Security Consideration
No


## Test Result
Feature tested on testnet, verified the function is fully working and indexed corrected.

## Ecosystem Impact
first step of https://aptosfoundation.org/currents/migrating-to-fungible-asset-standard
All the ecosystem projects should be ready for this change.
