### PR TITLE
Disable CONCURRENT_FUNGIBLE_BALANCE

### DIFF
--- a/metadata/2025-06-12-disable-concurrent-fa-balance/disable_concurrent_fungible_balance.json
+++ b/metadata/2025-06-12-disable-concurrent-fa-balance/disable_concurrent_fungible_balance.json
@@ -1,6 +1,6 @@
 {
   "title": "Disable CONCURRENT_FUNGIBLE_BALANCE",
-  "description": "To prevent issues before the fix, we should consider disabling the CONCURRENT_FUNGIBLE_BALANCE feature flag ahead of the coin-to-fungible store rollout.",
+  "description": "This proposal temporarily disables the use of aggregator-based concurrent fungible store due to a known issue involving epilogue execution, which can cause unintended aborts in certain cases.",
   "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-06-12-disable-concurrent-fa-balance/0-features.move",
   "discussion_url": "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-70.md"
 }

--- a/metadata/2025-06-12-disable-concurrent-fa-balance/disable_concurrent_fungible_balance.json
+++ b/metadata/2025-06-12-disable-concurrent-fa-balance/disable_concurrent_fungible_balance.json
@@ -1,0 +1,6 @@
+{
+  "title": "Disable CONCURRENT_FUNGIBLE_BALANCE",
+  "description": "To prevent issues before the fix, we should consider disabling the CONCURRENT_FUNGIBLE_BALANCE feature flag ahead of the coin-to-fungible store rollout.",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/blob/main/sources/2025-06-12-disable-concurrent-fa-balance/0-features.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-70.md"
+}

--- a/sources/2025-06-12-disable-concurrent-fa-balance/0-features.move
+++ b/sources/2025-06-12-disable-concurrent-fa-balance/0-features.move
@@ -1,0 +1,24 @@
+// Script hash: 0ac88249 
+// Modifying on-chain feature flags:
+// Enabled Features: []
+// Disabled Features: [ConcurrentFungibleBalance]
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+            67,
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
currently there are some issues with “aggregators” and epilogue, that move team is working on fixing. Consequence is that some usage of concurrent fungible store to pay gas will abort, when it shouldn’t. So we need to disable it temporarily and re-enable it after the fix
AIP: 70
Release: aptos-release-v1.31
Type: Technical

## Security Consideration
No security concern since it was disabled before.


## Test Result
Feature was disabled before.

## Ecosystem Impact
No impact
