### PR TITLE
enable public structs as transaction arguments

### DIFF
--- a/metadata/2026-05-14-public-args/public_struct_enum_args.json
+++ b/metadata/2026-05-14-public-args/public_struct_enum_args.json
@@ -1,0 +1,6 @@
+{
+  "title": "Proposal to enable public structs and enums as transaction arguments",
+  "description": "public structs and enums (AIP-142, https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-142-public-structs-and-enums.md).",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/tree/main/sources/2026-05-14-public-args/0-features.move",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/671"
+}

--- a/sources/2026-05-14-public-args/0-features.move
+++ b/sources/2026-05-14-public-args/0-features.move
@@ -1,0 +1,24 @@
+// Script hash: 2ffb4214 
+// Modifying on-chain feature flags:
+// Enabled Features: [PublicStructEnumArgs]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+            109,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a short summary about this new proposal, add AIP link here if it's corresponding to an AIP. If it does not associated with any AIP, explain why this is required-->

AIP: [142](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-142-public-structs-and-enums.md)

Release: 1.44
Type: Technical

Security Consideration
Audited by OtterSec; no security concerns identified.

Test Result
Feature enabled & tested on testnet since 1.44.

Ecosystem Impact
all validator and full nodes need to be upgraded to 1.44 or above

<!-- Thank you for your contribution! -->
