### PR TITLE
Enable transaction limits (AIP-146)

### DIFF
--- a/metadata/2026-06-22-enable-transaction-limits/enable-transaction-limits.json
+++ b/metadata/2026-06-22-enable-transaction-limits/enable-transaction-limits.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable transaction limits",
+  "description": "AIP-146 staking-based transaction limits. Sets transaction_limits execution/IO tiers (2x/4x/8x by staked APT) and enables versioned_transaction_validation and transaction_limits. https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-146-staking-based-transaction-limits.md",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/tree/main/sources/2026-06-22-enable-transaction-limits",
+  "discussion_url": "https://github.com/aptos-foundation/AIPs/issues/669"
+}

--- a/sources/2026-06-22-enable-transaction-limits/0-update-transaction-limits.move
+++ b/sources/2026-06-22-enable-transaction-limits/0-update-transaction-limits.move
@@ -1,0 +1,39 @@
+// Script hash: 77912052 
+// Set transaction_limits execution and IO tiers via governance (AIP-146).
+// Execution: 2x @ 1M APT, 4x @ 5M APT, 8x @ 10M APT.
+// IO:        2x @ 5M APT, 4x @ 10M APT, 8x @ 20M APT.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::transaction_limits;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            vector[29u8,113u8,101u8,132u8,155u8,166u8,213u8,150u8,48u8,153u8,46u8,175u8,185u8,114u8,172u8,131u8,201u8,151u8,166u8,86u8,112u8,25u8,42u8,147u8,217u8,85u8,3u8,248u8,200u8,227u8,84u8,71u8,],
+        );
+
+        // Octas = APT * 10^8.
+        let execution_min_stakes = vector[
+            100_000_000_000_000,    //  1 M APT
+            500_000_000_000_000,    //  5 M APT
+          1_000_000_000_000_000,    // 10 M APT
+        ];
+        let execution_multipliers_percent = vector[200, 400, 800];
+
+        let io_min_stakes = vector[
+            500_000_000_000_000,    //  5 M APT
+          1_000_000_000_000_000,    // 10 M APT
+          2_000_000_000_000_000,    // 20 M APT
+        ];
+        let io_multipliers_percent = vector[200, 400, 800];
+
+        transaction_limits::update_config(
+            &framework_signer,
+            execution_min_stakes,
+            execution_multipliers_percent,
+            io_min_stakes,
+            io_multipliers_percent,
+        );
+    }
+}

--- a/sources/2026-06-22-enable-transaction-limits/1-features.move
+++ b/sources/2026-06-22-enable-transaction-limits/1-features.move
@@ -1,0 +1,24 @@
+// Script hash: 1d716584 
+// Modifying on-chain feature flags:
+// Enabled Features: [VersionedTransactionValidation, TransactionLimits]
+// Disabled Features: []
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"");
+
+        let enabled_blob: vector<u64> = vector[
+            112, 111,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+
+        ];
+
+        features::change_feature_flags_for_next_epoch(&framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(&framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
Multi-step governance proposal for AIP-146 staking-based transaction limits.

- Step 0 (`0-update-transaction-limits.move`): sets `transaction_limits` execution/IO tiers (2x/4x/8x by staked APT) via `transaction_limits::update_config`.
- Step 1 (`1-features.move`): enables feature flags `versioned_transaction_validation` (112) and `transaction_limits` (111).

Config is set before the flags so the `TxnLimitsConfig` resource exists before the flags take effect.

AIP: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-146-staking-based-transaction-limits.md
Release:
Type: Technical

## Security Consideration
Feature-flag + config-only governance proposal; no framework code change. Both flags are gated on-chain so high limits only enforce when both 112 and 111 are enabled.

## Test Result
Simulated both steps against current mainnet state with `aptos-release-builder simulate --network mainnet`. Both scripts succeeded (`0-update-transaction-limits.move` and `1-features.move`).

## Ecosystem Impact
Raises execution/IO limits for transactions backed by sufficient staked APT, per AIP-146. No action required from node operators.