### PR TITLE
Enable ChunkyDKG Shadow V1

### DIFF
--- a/metadata/2026-08-20-enable-chunky-dkg-shadow-v1/enable_chunky_dkg_shadow_v1.json
+++ b/metadata/2026-08-20-enable-chunky-dkg-shadow-v1/enable_chunky_dkg_shadow_v1.json
@@ -1,0 +1,6 @@
+{
+  "title": "Initialize Encrypted Mempool Framework and Enable ChunkyDKG Shadow V1",
+  "description": "Initialize encrypted-mempool framework resources, then enable ChunkyDKG in shadow mode (1/2 secrecy, 2/3 reconstruction, 120s grace period).",
+  "source_code_url": "https://github.com/aptos-foundation/mainnet-proposals/tree/main/sources/2026-08-20-enable-chunky-dkg-shadow-v1",
+  "discussion_url": "https://github.com/aptos-labs/aptos-core"
+}

--- a/sources/2026-08-20-enable-chunky-dkg-shadow-v1/0-encrypted_mempool_initialization.move
+++ b/sources/2026-08-20-enable-chunky-dkg-shadow-v1/0-encrypted_mempool_initialization.move
@@ -1,0 +1,29 @@
+// Script hash: 95c1eaea
+// Initialize on-chain resources for the encrypted mempool stack: ChunkyDKG
+// (config + seqnum + state), the epoch force-end watchdog, and the per-block
+// decryption key.
+//
+// Each `initialize` call is a no-op if its resource already exists, so this is
+// safe to run even if some of these resources were created previously.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::chunky_dkg;
+    use aptos_framework::chunky_dkg_config;
+    use aptos_framework::chunky_dkg_config_seqnum;
+    use aptos_framework::decryption;
+    use aptos_framework::epoch_timeout_config;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            vector[246u8,66u8,107u8,110u8,245u8,72u8,74u8,75u8,63u8,166u8,235u8,53u8,158u8,51u8,8u8,103u8,71u8,33u8,210u8,41u8,19u8,193u8,138u8,173u8,71u8,71u8,167u8,217u8,187u8,38u8,254u8,121u8,],
+        );
+
+        chunky_dkg_config_seqnum::initialize(&framework);
+        chunky_dkg_config::initialize(&framework, chunky_dkg_config::new_off());
+        chunky_dkg::initialize(&framework);
+        epoch_timeout_config::initialize(&framework);
+        decryption::initialize(&framework);
+    }
+}

--- a/sources/2026-08-20-enable-chunky-dkg-shadow-v1/1-enable_chunky_dkg_shadow_v1.move
+++ b/sources/2026-08-20-enable-chunky-dkg-shadow-v1/1-enable_chunky_dkg_shadow_v1.move
@@ -1,0 +1,25 @@
+// Script hash: f6426b6e
+// Enable ChunkyDKG in shadow mode (ConfigShadowV1).
+// Prerequisite: ChunkyDKG framework resources must already be initialized
+// (see encrypted_mempool_initialization.move).
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::chunky_dkg_config;
+    use aptos_std::fixed_point64;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            vector[],
+        );
+
+        let config = chunky_dkg_config::new_shadow_v1(
+            fixed_point64::create_from_rational(1, 2), // secrecy_threshold: 1/2
+            fixed_point64::create_from_rational(2, 3), // reconstruction_threshold: 2/3
+            120,                                       // grace_period_secs
+        );
+        chunky_dkg_config::set_for_next_epoch(&framework, config);
+        aptos_governance::reconfigure(&framework);
+    }
+}


### PR DESCRIPTION
## Description

This is part 1 of a two part proposal to enable encrypted mempool (AIP-144) on mainnet.

This PR adds a two-step governance proposal to initialize the encrypted-mempool framework resources and enable ChunkyDKG Shadow V1 on mainnet.

- Step 0 (`0-encrypted_mempool_initialization.move`): idempotently initializes the ChunkyDKG config, sequence number and state, epoch-timeout config, and decryption resources.
- Step 1 (`1-enable_chunky_dkg_shadow_v1.move`): enables `ConfigShadowV1` with a 1/2 secrecy threshold, 2/3 reconstruction threshold, and 120-second grace period, then reconfigures.

AIP: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-144-encrypted-mempool.md
Release: v1.48
Type: Technical

## Security Consideration

The design and implementation has been audited by zkSecurity.

https://reports.zksecurity.xyz/reports/aptos-encrypted-mempool/

## Test Result
Baked in testnet for 2.5 months.

## Ecosystem Impact

N/A